### PR TITLE
Automate Lets Encrypt Renewal

### DIFF
--- a/config/automations/system/letsencrypt_renewal.yaml
+++ b/config/automations/system/letsencrypt_renewal.yaml
@@ -1,0 +1,10 @@
+---
+alias: Lets Encrypt Renewal
+trigger:
+- platform: time
+  at: '00:00:00'
+action:
+- data:
+    addon: core_letsencrypt
+  service: hassio.addon_restart
+initial_state: true


### PR DESCRIPTION


# Proposed Changes

Restarts Lets Encrypt Add-on daily to check/renew certificates

## Related Issues

https://github.com/frenck/home-assistant-config/issues/4

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/