### PR TITLE
Add missing "Compact Custom Header" include

### DIFF
--- a/config/lovelace/views/downstairs.yaml
+++ b/config/lovelace/views/downstairs.yaml
@@ -3,6 +3,7 @@ id: downstairs
 title: Beneden
 icon: mdi:sofa
 cards:
+  - !include ../cards/compact_custom_header.yaml
   - type: vertical-stack
     cards:
       - type: entities


### PR DESCRIPTION
# Proposed Changes

"Compact Custom Header" include is missing in this view.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/