### PR TITLE
telegram_bot_conversation: escape markdown

### DIFF
--- a/config/custom_components/telegram_bot_conversation/__init__.py
+++ b/config/custom_components/telegram_bot_conversation/__init__.py
@@ -26,6 +26,7 @@ from homeassistant.components.telegram_bot import (
     EVENT_TELEGRAM_TEXT,
     SERVICE_SEND_MESSAGE,
 )
+from telegram.utils.helpers import escape_markdown
 
 DOMAIN = "telegram_bot_conversation"
 
@@ -47,7 +48,7 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:
             TELEGRAM_DOMAIN,
             SERVICE_SEND_MESSAGE,
             {
-                ATTR_MESSAGE: response.speech["plain"]["speech"],
+                ATTR_MESSAGE: escape_markdown(response.speech["plain"]["speech"]),
                 ATTR_TARGET: event.data[ATTR_USER_ID],
             },
         )


### PR DESCRIPTION
# Proposed Changes

Handle underscore characters in response correctly. If unescaped, telegram_bot will fail to parse the text.

## Related Issues

N/A