### PR TITLE
Update maintenance shield to 2022.

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ SOFTWARE.
 [home-assistant]: https://home-assistant.io
 [issue]: https://github.com/frenck/home-assistant-config/issues
 [license-shield]: https://img.shields.io/github/license/frenck/home-assistant-config.svg
-[maintenance-shield]: https://img.shields.io/maintenance/yes/2020.svg
+[maintenance-shield]: https://img.shields.io/maintenance/yes/2022.svg
 [last-commit-shield]: https://img.shields.io/github/last-commit/frenck/home-assistant-config.svg
 [stars-shield]: https://img.shields.io/github/stars/frenck/home-assistant-config.svg?style=social&label=Stars
 [forks-shield]: https://img.shields.io/github/forks/frenck/home-assistant-config.svg?style=social&label=Forks


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

I updated the maintenance shield URL to 2022
## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
